### PR TITLE
1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ the string being tested to the baseline string. Then save the file as
     expected = Baseline("""
         """)
 
-    test_string = "THE QUICK BROWN FOX\n    JUMPS\nOVER THE LAZY DOG."
+    test_string = """THE QUICK BROWN FOX
+        JUMPS
+    OVER THE LAZY DOG."""
 
     assert test_string == expected
 
@@ -55,7 +57,9 @@ source file but changed the file name to ``fox.update.py``:
         OVER THE LAZY DOG.
         """)
 
-    test_string = "THE QUICK BROWN FOX\n    JUMPS\nOVER THE LAZY DOG."
+    test_string = """THE QUICK BROWN FOX
+        JUMPS
+    OVER THE LAZY DOG."""
 
     assert test_string == expected
 
@@ -77,7 +81,7 @@ scripts and accept them:
 
 
 Run ``fox.py`` again and observe the ``assert`` does not raise an exception
-nor is a source file update generated. If in the future the test value
-changes, the ``assert`` will raise an exception and cause a new source file
+nor is a copy of the source file update generated. If in the future the test
+value changes, the ``assert`` raises an exception and causes a new source file
 update to be generated. Simply repeat the review and acceptance step and you
 are back in business!

--- a/baseline/__about__.py
+++ b/baseline/__about__.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,5 +35,5 @@ __version__      = "{0.major}.{0.minor}.{0.micro}{1}{2}".format(__version_info__
 __author__       = "Dan Gass"
 __maintainer__   = "Dan Gass"
 __email__        = "dan.gass@gmail.com"
-__copyright__    = "Copyright 2018 Daniel Mark Gass"
+__copyright__    = "Copyright 2020 Daniel Mark Gass"
 __license__      = "MIT License ; http://opensource.org/licenses/MIT"

--- a/baseline/__init__.py
+++ b/baseline/__init__.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,21 +25,4 @@ from __future__ import absolute_import, division, print_function
 
 from .__about__ import * ; del __about__
 
-from ._baseline import Baseline
-
-
-class RawBaseline(Baseline):
-
-    """Baselined string.
-
-    Support comparison of a string against this baseline. When the comparison
-    results in a mismatch, make a copy of the Python script containing the
-    baseline and modify the baseline to match the new value.
-
-    When updating baseline string, use raw multi-line string form when
-    possible so that backslashes present in baselined string only appear
-    as a single character in the source file.
-
-    """
-
-    _AVOID_RAW_FORM = False
+from ._baseline import Baseline, RawBaseline

--- a/baseline/__main__.py
+++ b/baseline/__main__.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,9 +36,10 @@ UPDATE_EXT = '.update.py'
 DESCRIPTION = """
 Locate scripts with baseline updates within the paths specified and modify 
 the scripts with the updates found. (The scripts to be modified will be 
-summarized and you will be offered a chance to cancel before files are
+summarized and you will be offered a chance to cancel before files are 
 changed.)
 """.strip()
+
 
 def main(args=None):
     """Command line interface.

--- a/baseline/_baseline.py
+++ b/baseline/_baseline.py
@@ -333,5 +333,6 @@ class RawBaseline(Baseline):
     """
 
     def __new__(cls, text):
-        warn('RawBaseline() deprecated, use Baseline() instead', DeprecationWarning)
+        warn('RawBaseline() deprecated, use equivalent Baseline() instead',
+             DeprecationWarning)
         return super(RawBaseline, cls).__new__(cls, text)

--- a/baseline/_baseline.py
+++ b/baseline/_baseline.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ import atexit
 import inspect
 import os
 import sys
+from warnings import warn
 
 from ._script import Script
 
@@ -38,7 +39,7 @@ SEPARATOR = '\n' + '*' * 40 + '\n'
 
 baseclass = type(u"")
 
-RAW_MULTILINE_CHARS = ('\n', '"', '\\')
+RAW_STRING_SPECIAL_CHARS = ('\n', '"', '\\')
 
 
 def multiline_repr(text, special_chars=('\n', '"')):
@@ -49,8 +50,8 @@ def multiline_repr(text, special_chars=('\n', '"')):
     use of the representation in a triple quoted multi-line string
     context (to avoid escaping newlines and double quotes).
 
-     Pass ``RAW_MULTILINE_CHARS`` as the ``special_chars`` when use
-     context is a "raw" triple quoted string (to also avoid excaping
+     Pass ``RAW_STRING_SPECIAL_CHARS`` as the ``special_chars`` when use
+     context is a "raw" triple quoted string (to also avoid escaping
      backslashes).
 
     :param text: string
@@ -73,16 +74,17 @@ def multiline_repr(text, special_chars=('\n', '"')):
 
 class Baseline(baseclass):
 
-    """Baselined string.
+    """Baseline string.
 
     Support comparison of a string against this baseline. When the comparison
     results in a mismatch, make a copy of the Python script containing the
     baseline and modify the baseline to match the new value.
 
     """
+
     TRANSFORMS = []
 
-    _AVOID_RAW_FORM = True
+    _AVOID_RAW_FORM = False
 
     # set of instances of this class where a string comparison against the
     # baseline was a mismatch
@@ -121,17 +123,17 @@ class Baseline(baseclass):
             indent = 0
 
         elif lines[0].strip():
-            raise ValueError('when multiple lines, first line must be blank')
+            raise ValueError('when multiple lines in baseline text, first line must be blank')
 
         elif lines[-1].strip():
-            raise ValueError('last line must only contain indent whitespace')
+            raise ValueError('last line in baseline text must only contain indent whitespace')
 
         else:
             indent = len(lines[-1])
 
             if any(line[:indent].strip() for line in lines):
                 raise ValueError(
-                    'indents must equal or exceed indent in last line')
+                    'indents must equal or exceed indent in last line of baseline text')
 
             lines = [line[indent:] for line in lines][1:-1]
 
@@ -146,39 +148,38 @@ class Baseline(baseclass):
         source file (i.e. when multi-line, remove common indentation
         as well as the first and last lines).
 
-        :param text: baselined string representation
-        :type text: str or unicode
-        :returns: normalized string representation
+        :param str text: baselined string
+        :returns: normalized baseline string
         :raises RuntimeError: when text differs for a specific location
 
         """
         frame = inspect.getouterframes(inspect.currentframe())[1]
         path = os.path.abspath(frame[1])
         linenum = frame[2]
+        indent, dedented_text = cls._dedent(text)
 
         key = (path, linenum)
 
         try:
-            self = cls._all_instances[key]
+            baseline = cls._all_instances[key]
         except KeyError:
-            indent, dedented_text = cls._dedent(text)
-            self = super(Baseline, cls).__new__(cls, dedented_text)
-            cls._all_instances[key] = self
+            baseline = super(Baseline, cls).__new__(cls, dedented_text)
+            cls._all_instances[key] = baseline
 
             # initialize instance here instead of __init__ to avoid:
             #   (1) reinitializing when returning a pre-existing instance
             #   (2) recomputing path and linenum (or corrupting class signature
             #       by passing them to __init__)
-            self.z__path = path
-            self.z__linenum = linenum
-            self._indent = indent
-            self._updates = set()
+            baseline._path = path
+            baseline._linenum = linenum
+            baseline._indent = indent
+            baseline._updates = set()
 
         else:
-            if baseclass.__ne__(self, text):
+            if baseclass.__ne__(baseline, dedented_text):
                 raise RuntimeError('varying baseline text not allowed')
 
-        return self
+        return baseline
 
     def __eq__(self, text):
         """Compare string against baseline.
@@ -199,7 +200,7 @@ class Baseline(baseclass):
         # triple double quote is present to avoid syntax errors
         if '"""' in text and "'''" in text:
             raise ValueError(
-                'Both triple quote styles exist in string, '
+                'Both triple quote styles exist in string to be baselined, '
                 'replace either """ or {} before baselining'.format("'''"))
 
         # Save a copy of the string in order to later update the string
@@ -231,53 +232,53 @@ class Baseline(baseclass):
         return id(self)
 
     @property
-    def z__update(self):
-        """Triple quoted baseline representation.
-
-        Return string with multiple triple quoted baseline strings when
-        baseline had been compared multiple times against varying strings.
+    def replacement_sourcecode(self):
+        """Baseline replacement source code lines.
 
         :returns: source file baseline replacement text
         :rtype: str
 
         """
-        updates = []
+        # sort updates so Python hash seed has no impact on regression test
+        updates = [update for update in sorted(self._updates)]
 
-        for text in self._updates:
+        if len(updates) > 1:
+            for i, text in enumerate(updates):
+                header = '\n'.join([
+                    '######################' * 5,
+                    '# Baseline Alternative {}'.format(i + 1),
+                    '######################' * 5])
+                updates[i] = header + '\n' + text
 
-            if self._AVOID_RAW_FORM:
-                text_repr = multiline_repr(text)
-                raw_char = ''
+        text = '\n'.join(updates)
+
+        text_repr = multiline_repr(text, RAW_STRING_SPECIAL_CHARS)
+
+        if text_repr == text:
+            raw_char = 'r' if '\\' in text_repr else ''
+        else:
+            # must have special characters that required added backslash
+            # escaping, use normal representation to get backslashes right
+            text = multiline_repr(text)
+            raw_char = ''
+
+        # use triple double quote, except use triple single quote when
+        # triple double quote is present to avoid syntax errors
+        quotes = '"""'
+        if quotes in text:
+            if "'''" in text:
+                text.replace("'''", "```")
             else:
-                text_repr = multiline_repr(text, RAW_MULTILINE_CHARS)
-
-                if len(text_repr) == len(text):
-                    raw_char = 'r' if '\\' in text_repr else ''
-                else:
-                    # must have special characters that required added backslash
-                    # escaping, use normal representation to get backslashes right
-                    text_repr = multiline_repr(text)
-                    raw_char = ''
-
-            # use triple double quote, except use triple single quote when
-            # triple double quote is present to avoid syntax errors
-            quotes = '"""'
-            if quotes in text:
                 quotes = "'''"
 
-            # Wrap with blank lines when multi-line or when text ends with
-            # characters that would otherwise result in a syntax error in
-            # the formatted representation.
-            multiline = self._indent or ('\n' in text)
-            if multiline or text.endswith('\\') or text.endswith(quotes[0]):
-                update = raw_char + quotes + '\n' + text_repr + '\n' + quotes
-            else:
-                update = raw_char + quotes + text_repr + quotes
-
-            updates.append(update)
-
-        # sort updates so Python hash seed has no impact on regression test
-        update = '\n'.join(sorted(updates))
+        # Wrap with blank lines when multi-line or when text ends with
+        # characters that would otherwise result in a syntax error in
+        # the formatted representation.
+        multiline = self._indent or ('\n' in text)
+        if multiline or text.endswith('\\') or text.endswith(quotes[0]):
+            update = raw_char + quotes + '\n' + text + '\n' + quotes
+        else:
+            update = raw_char + quotes + text + quotes
 
         indent = ' ' * self._indent
 
@@ -303,19 +304,34 @@ class Baseline(baseclass):
 
         for baseline in cls._baselines_to_update:
 
-            if baseline.z__path.endswith('<stdin>'):
+            if baseline._path.endswith('<stdin>'):
                 continue
 
             try:
-                script = updated_scripts[baseline.z__path]
+                script = updated_scripts[baseline._path]
             except KeyError:
-                script = Script(baseline.z__path)
-                updated_scripts[baseline.z__path] = script
+                script = Script(baseline._path)
+                updated_scripts[baseline._path] = script
 
-            script.add_update(baseline.z__linenum, baseline.z__update)
+            script.add_update(baseline._linenum, baseline.replacement_sourcecode)
 
         for key in sorted(updated_scripts):
             script = updated_scripts[key]
             script.update()
 
         return updated_scripts
+
+
+class RawBaseline(Baseline):
+
+    """Baselined string.
+
+    Support comparison of a string against this baseline. When the comparison
+    results in a mismatch, make a copy of the Python script containing the
+    baseline and modify the baseline to match the new value.
+
+    """
+
+    def __new__(cls, text):
+        warn('RawBaseline() deprecated, use Baseline() instead', DeprecationWarning)
+        return super(RawBaseline, cls).__new__(cls, text)

--- a/baseline/_baseline.py
+++ b/baseline/_baseline.py
@@ -84,8 +84,6 @@ class Baseline(baseclass):
 
     TRANSFORMS = []
 
-    _AVOID_RAW_FORM = False
-
     # set of instances of this class where a string comparison against the
     # baseline was a mismatch
     _baselines_to_update = set()

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -14,7 +14,6 @@ Classes
 
 .. autoclass:: Baseline
 
-.. autoclass:: RawBaseline
 
 
 ************

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,32 +2,49 @@
 [baseline] Release Notes
 ########################
 
-Versions are incremented according to `semver <http://semver.org/>`_.
+Versions increment per `semver <http://semver.org/>`_.
 
-***
-0.2
-***
 
-+ 0.2.0 (2018-05-18)
-    - Add ``--movepath`` command line option to move updated scripts to
-      a new location instead of overwriting the original script (for
-      use in continuous integration systems performing regression tests).
+******************
+1.0.0 2020-MAR-TBD
+******************
+
++ Improve baseline update when multiple values compared against the
+  same baseline. Generate a single multi-line baseline with headers
+  between the various alternative values. This facilitates updating
+  the baseline again.
+
++ Support Python 3.8. Previously, when run using 3.8, the baseline
+  update tool misplaced baseline updates in the first triple quoted
+  string found above the baseline. (Python 3.8 stack frames now
+  report the line number of the first line in a statement rather
+  than the last.)
+
++ Change behavior of ``Baseline`` to use raw strings when updating
+  baselines when possible.
+
++ Deprecate ``RawBaseline`` since ``Baseline`` now incorporates
+  that behavior.
+
+
+*************
+Beta Releases
+*************
 
 + 0.2.1 (2018-05-19)
     - Fix command line tool to not raise UnboundedLocalError exception.
       Previously when tool was invoked with a wild card that yielded
       no baseline updates to move, an exception was unexpectedly raised.
 
++ 0.2.0 (2018-05-18)
+    - Add ``--movepath`` command line option to move updated scripts to
+      a new location instead of overwriting the original script (for
+      use in continuous integration systems performing regression tests).
 
-***
-0.1
-***
-
-+ 0.1.0 (2018-03-25)
-    - Initial "beta" release.
-
-+ 0.1.1 (2018-03-25)
-    - Change author to match PyPi user name.
++ 0.1.3 (2018-03-29)
+    - Show command line help dump in API reference documentation.
+    - Fix development status classifier in setup configuration
+      (to make PyPi listing accurate).
 
 + 0.1.2 (2018-03-27)
     - Add Travis C/I support.
@@ -35,7 +52,8 @@ Versions are incremented according to `semver <http://semver.org/>`_.
     - Use Python 3.5 in tox for basic tasks.
     - Remove "beta" label.
 
-+ 0.1.3 (2018-03-29)
-    - Show command line help dump in API reference documentation.
-    - Fix development status classifier in setup configuration
-      (to make PyPi listing accurate).
++ 0.1.1 (2018-03-25)
+    - Change author to match PyPi user name.
+
++ 0.1.0 (2018-03-25)
+    - Initial "beta" release.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -5,9 +5,9 @@
 Versions increment per `semver <http://semver.org/>`_.
 
 
-******************
-1.0.0 2020-MAR-TBD
-******************
+*****************
+1.0.0 2020-MAR-19
+*****************
 
 + Improve baseline update when multiple values compared against the
   same baseline. Generate a single multi-line baseline with headers
@@ -21,10 +21,10 @@ Versions increment per `semver <http://semver.org/>`_.
   than the last.)
 
 + Change behavior of ``Baseline`` to use raw strings when updating
-  baselines when possible.
+  baselines when possible and improves readability.
 
 + Deprecate ``RawBaseline`` since ``Baseline`` now incorporates
-  that behavior.
+  its behavior.
 
 
 *************

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -198,32 +198,3 @@ with the closing triple quote:
 
 Run the script and let the tool fill in the string baseline. Then carefully
 review the baseline update and accept.
-
-
-Raw String Baseline
-===================
-
-If the baseline string contains backslashes and no other special characters
-that require escaping, use the :class:`RawBaseline` class to generate
-baseline updates with a raw string format. This provides a more readable
-form for strings that contain such things as Microsoft Windows style paths
-where backslashes are present:
-
-.. code-block:: python
-
-    from baseline import Baseline, RawBaseline
-
-    test_string = 'Some path: C:\\samples\\hello.py'
-
-    # slightly more difficult to read with two backslashes for every one
-    expected = Baseline("""Some path: C:\\samples\\hello.py""")
-    assert test_string == expected
-
-    # a little prettier form with backslashes not required to be escaped
-    expected = RawBaseline(r"""Some path: C:\samples\hello.py""")
-    assert test_string == expected
-
-.. Note::
-    If special characters that require a backslash to represent are present
-    in a miscompared test string (such as chr(0) or the tab character), the
-    baseline update switches to use the normal, non-raw string form.

--- a/notes.txt
+++ b/notes.txt
@@ -8,6 +8,13 @@ TODO
 5) set up RTD to contain docs for multiple revisions
 
 
+Running Tox locally (running tests)
+-----------------------------------
+
+$ python -m pip install tox
+$ tox -e py37
+
+
 Building/Publishing Instructions
 --------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/endswith.py
+++ b/tests/endswith.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,6 @@ quote = Baseline("""
     ENDSWITH "
     """)
 
-backslash = Baseline("""
-    ENDSWITH \\
+backslash = Baseline(r"""
+    ENDSWITH \
     """)

--- a/tests/indents.py
+++ b/tests/indents.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/raw.py
+++ b/tests/raw.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,10 +22,10 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from baseline import RawBaseline
+from baseline import Baseline
 
-lower = RawBaseline(r"""LOWER""")  # lower case "r" present
+lower = Baseline(r"""LOWER""")  # lower case "r" present
 
-upper = RawBaseline(R"""UPPER""")  # upper case "R" present
+upper = Baseline(R"""UPPER""")  # upper case "R" present
 
-missing = RawBaseline("""MISSING""")  # no "raw" designator present
+missing = Baseline("""MISSING""")  # no "raw" designator present

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/simple.py
+++ b/tests/simple.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tests/special.py
+++ b/tests/special.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,7 @@ from baseline import Baseline
 
 double_quote = Baseline("""SPECIAL ["]""")
 
-backslash = Baseline("""SPECIAL [\\]""")
+backslash = Baseline("""BACKSLASH [\\]""")
 
 tab = Baseline("""SPECIAL [\t]""")
 

--- a/tests/whitespace.py
+++ b/tests/whitespace.py
@@ -1,5 +1,5 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# Copyright 2018 Daniel Mark Gass
+# Copyright 2020 Daniel Mark Gass
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}, coverage, docs
+envlist = py{27,34,35,36,37,38}, coverage, docs
 minversion = 2.5.0
 
 [base]
@@ -12,7 +12,7 @@ extras = test
 deps =
 
 [testenv:prepare]
-basepython = python3.5
+basepython = python3.8
 skip_install = true
 whitelist_externals=*/.build
 commands =
@@ -24,7 +24,7 @@ commands =
     {[testenv]commands}
 
 [testenv:coverage]
-basepython = python3.5
+basepython = python3.8
 commands =
     {envpython} -m coverage erase
     -{envpython} -B -m coverage run -m tests {posargs}
@@ -35,7 +35,7 @@ deps =
     coverage>=4.4.2
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.8
 commands =
    #{envpython} -m sphinx.apidoc -f -e -M -o {toxinidir}/docs/api {envsitepackagesdir}/{[base]packagesubdir}
     {envpython} setup.py -v build_sphinx -E           -d {envtmpdir}/doctrees {toxinidir}/docs {distdir}/html
@@ -44,7 +44,7 @@ commands =
 extras = doc
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.8
 skip_install = true
 commands =
     {envpython} -m flake8 {envsitepackagesdir}/{[base]packagesubdir}/ setup.py


### PR DESCRIPTION
+ Improve baseline update when multiple values compared against the
  same baseline. Generate a single multi-line baseline with headers
  between the various alternative values. This facilitates updating
  the baseline again.

+ Support Python 3.8. Previously, when run using 3.8, the baseline
  update tool misplaced baseline updates in the first triple quoted
  string found above the baseline. (Python 3.8 stack frames now
  report the line number of the first line in a statement rather
  than the last.)

+ Change behavior of ``Baseline`` to use raw strings when updating
  baselines when possible and improves readability.

+ Deprecate ``RawBaseline`` since ``Baseline`` now incorporates
  its behavior.
